### PR TITLE
fix(BUG-PY-001): use camelCase JSON keys in Event headers

### DIFF
--- a/event_people/event.py
+++ b/event_people/event.py
@@ -16,6 +16,16 @@ class Header:
         self.destination = destination
         self.schema_version = schema_version or 1.0
 
+    def to_dict(self):
+        return {
+            'appName': self.app,
+            'schemaVersion': self.schema_version,
+            'resource': self.resource,
+            'origin': self.origin,
+            'action': self.action,
+            'destination': self.destination,
+        }
+
     def __str__(self):
         return f'{self.app}.{self.resource}.{self.origin}.{self.action}.{self.destination}.{self.schema_version}'
 
@@ -50,4 +60,4 @@ class Event(object):
         return f'{name}.all' if len(name.split('.')) == 3 else name
 
     def payload(self):
-       return json.dumps({"headers": self.header.__dict__, "body": self.body})
+       return json.dumps({"headers": self.header.to_dict(), "body": self.body})

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -34,7 +34,7 @@ class TestEvent:
         resp = json.loads(event.payload())
 
         header = resp['headers']
-        assert header['app'] == 'service_name'
+        assert header['appName'] == 'service_name'
         assert header['resource'] == 'resource'
         assert header['origin'] == 'custom'
 


### PR DESCRIPTION
## Problem

`Header` class attributes use Python naming (`schema_version`, `app_name`, etc.) and were serialized via `__dict__`, producing **snake_case JSON keys**. The spec requires **camelCase** keys (`appName`, `schemaVersion`) in all implementations for cross-language compatibility.

Events produced by Python could not be correctly parsed by Ruby or Go consumers.

## Fix

Added `Header.to_dict()` method that explicitly returns a dict with camelCase keys:
- `appName`, `schemaVersion`, `resource`, `origin`, `action`, `destination`

Updated `Event.payload()` to call `to_dict()` instead of `__dict__`.

## References
- Spec: `spec/contract.yml → Event.headers` (camelCase requirement)
- Bug ID: `BUG-PY-001` in `.event_people.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved event payload serialization for more consistent header field representation in emitted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->