### PR TITLE
fix(BUG-PY-002): remove blocking start_consuming call from Emitter

### DIFF
--- a/event_people/emitter.py
+++ b/event_people/emitter.py
@@ -7,13 +7,8 @@ class Emitter:
 
     def itrigger(self, events):
         broker = Config.get_broker()
-        channel = broker.get_connection()
+        broker.get_connection()
 
         broker.produce(events)
-
-        try:
-            channel.start_consuming()
-        finally:
-            channel.stop_consuming()
 
         return events


### PR DESCRIPTION
## Problem

`Emitter.itrigger()` called `channel.start_consuming()` after `broker.produce()`. `start_consuming()` is a **blocking call** designed for consumers — it waits indefinitely for inbound messages. Calling it from an emitter blocks the entire process after publishing a single event.

## Fix

Removed the `try/finally` block containing `start_consuming()` / `stop_consuming()` from `itrigger()`. The emitter now calls `broker.produce()` and returns immediately.

## References
- Bug ID: `BUG-PY-002` in `.event_people.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)