### PR TITLE
fix(BUG-PY-003): change consumers from list to dict in BaseBroker

### DIFF
--- a/event_people/broker/base.py
+++ b/event_people/broker/base.py
@@ -1,6 +1,6 @@
 class Base:
     connection = None
-    consumers = []
+    consumers = {}
 
     def get_consumers(self):
         return self.consumers


### PR DESCRIPTION
## Problem

`BaseBroker` defined `consumers = []` (a list) at class level, but the code accessed it with string keys (`cls.consumers[event_name]`), raising `TypeError: list indices must be integers or slices, not str`.

## Fix

Changed the class-level definition from `consumers = []` to `consumers = {}`.

## References
- Bug ID: `BUG-PY-003` in `.event_people.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)