### PR TITLE
fix(BUG-PY-004): support 2-arg callbacks in Queue._callback

### DIFF
--- a/event_people/broker/rabbit/queue.py
+++ b/event_people/broker/rabbit/queue.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 from functools import partial
 from event_people.event import Event
@@ -47,7 +48,14 @@ class Queue:
         event = Event(event_name, payload)
         context = Context(channel, delivery_info)
 
-        callback(event, context, final_method_name)
+        try:
+            sig = inspect.signature(callback)
+            if len(sig.parameters) >= 3:
+                callback(event, context, final_method_name)
+            else:
+                callback(event, context)
+        except TypeError:
+            callback(event, context)
 
         if not continuous:
             channel.stop_consuming()

--- a/event_people/broker/rabbit/queue.py
+++ b/event_people/broker/rabbit/queue.py
@@ -49,12 +49,13 @@ class Queue:
         context = Context(channel, delivery_info)
 
         try:
-            sig = inspect.signature(callback)
-            if len(sig.parameters) >= 3:
-                callback(event, context, final_method_name)
-            else:
-                callback(event, context)
-        except TypeError:
+            param_count = len(inspect.signature(callback).parameters)
+        except (ValueError, TypeError):
+            param_count = 2
+
+        if param_count >= 3:
+            callback(event, context, final_method_name)
+        else:
             callback(event, context)
 
         if not continuous:


### PR DESCRIPTION
## Problem

`Queue._callback()` called `callback(event, context, final_method_name)` with 3 arguments. When a user registered a direct callback via `Listener.on(event_name, fn)` with `fn(event, context)` (2 args), this raised `TypeError: fn() takes 2 positional arguments but 3 were given`.

Only callbacks routed through `BaseListener.callback` (which accepts 3 args) worked correctly.

## Fix

Used `inspect.signature` to detect how many parameters the callable accepts. Calls with 3 args when the callback accepts ≥ 3 parameters, falls back to 2 args otherwise. A `TypeError` safety net handles edge cases.

## References
- Bug ID: `BUG-PY-004` in `.event_people.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event callback handling for improved compatibility and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->