### PR TITLE
feat: implement retry/DLQ (spec v1.1.0)

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
 spec_version: "1.1.0"
-implementation_version: "0.1.1"
+implementation_version: "0.1.2"
 language: python
 package: "event_people (PyPI)"
 status: stable
@@ -18,9 +18,6 @@ implemented:
   - RabbitContext
   - Topic
   - Queue
-
-# Spec components not yet implemented (pending in spec too)
-pending:
   - RetryManager
   - "Event.retryCount"
   - "Event.incrementRetryCount"
@@ -34,6 +31,9 @@ pending:
   - "RabbitContext.maxRetries"
   - "RabbitContext.isLastRetry"
   - "RabbitContext.dlqName"
+
+# Spec components not yet implemented (pending in spec too)
+pending:
   - "Config.fullUrl (built per-request in RabbitBroker._full_url instead)"
 
 # Structural or naming departures from the spec

--- a/event_people/broker/rabbit/context.py
+++ b/event_people/broker/rabbit/context.py
@@ -1,17 +1,53 @@
+import pika
+from event_people.broker.rabbit.retry_manager import RetryManager
+
+
 class RabbitContext:
-    """ Queue wrappper for python user"""
-    def __init__(self, channel, delivery_info):
+    """ Queue wrapper for python user"""
+    def __init__(self, channel, delivery_info, properties=None, queue_name=None,
+                 max_retries=3, delay_strategy='exponential', retry_count=0):
         self.channel = channel
         self.delivery_info = delivery_info
+        self.properties = properties
+        self.queue_name = queue_name
+        self.max_retries = max_retries
+        self.delay_strategy = delay_strategy
+        self.retry_count = retry_count
+        self._retry_manager = RetryManager(max_retries, delay_strategy)
+        self.dlq_name = None
+
+    @property
+    def is_last_retry(self):
+        return self.retry_count >= self.max_retries - 1
 
     def success(self):
         self.channel.basic_ack(self.delivery_info.delivery_tag)
 
     def fail(self):
-        self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=True)
+        if self._retry_manager.should_retry(self.retry_count):
+            delay = self._retry_manager.get_next_delay(self.retry_count)
+            retry_queue_name = f'{self.queue_name}_retry'
+            self.channel.basic_publish(
+                exchange='',
+                routing_key=retry_queue_name,
+                body=self._get_body(),
+                properties=pika.BasicProperties(
+                    expiration=str(delay),
+                    headers={'x-event-people-retries': self.retry_count + 1},
+                    delivery_mode=2,
+                ),
+            )
+            self.channel.basic_ack(self.delivery_info.delivery_tag)
+        else:
+            self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
 
     def reject(self):
         self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
+
+    def _get_body(self):
+        # Retrieve the original body from the last delivery via the channel's
+        # latest frame — we store it when the context is constructed.
+        return self._body if hasattr(self, '_body') else b''
 
 
 # Backward-compatibility alias

--- a/event_people/broker/rabbit/context.py
+++ b/event_people/broker/rabbit/context.py
@@ -5,7 +5,7 @@ from event_people.broker.rabbit.retry_manager import RetryManager
 class RabbitContext:
     """ Queue wrapper for python user"""
     def __init__(self, channel, delivery_info, properties=None, queue_name=None,
-                 max_retries=3, delay_strategy='exponential', retry_count=0):
+                 max_retries=3, delay_strategy='exponential', retry_count=0, body=None):
         self.channel = channel
         self.delivery_info = delivery_info
         self.properties = properties
@@ -15,6 +15,7 @@ class RabbitContext:
         self.retry_count = retry_count
         self._retry_manager = RetryManager(max_retries, delay_strategy)
         self.dlq_name = None
+        self._body = body if body is not None else b''
 
     @property
     def is_last_retry(self):
@@ -33,11 +34,17 @@ class RabbitContext:
                 body=self._get_body(),
                 properties=pika.BasicProperties(
                     expiration=str(delay),
-                    headers={'x-event-people-retries': self.retry_count + 1},
+                    headers={'x-event-people-retries': int(self.retry_count + 1)},
                     delivery_mode=2,
                 ),
             )
-            self.channel.basic_ack(self.delivery_info.delivery_tag)
+            try:
+                self.channel.basic_ack(self.delivery_info.delivery_tag)
+            except Exception:
+                # Publish already succeeded; swallow ack errors to avoid masking
+                # the successful retry enqueue. The original message may be
+                # redelivered once more but that is safer than losing the retry.
+                pass
         else:
             self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
 
@@ -45,9 +52,7 @@ class RabbitContext:
         self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
 
     def _get_body(self):
-        # Retrieve the original body from the last delivery via the channel's
-        # latest frame — we store it when the context is constructed.
-        return self._body if hasattr(self, '_body') else b''
+        return self._body
 
 
 # Backward-compatibility alias

--- a/event_people/broker/rabbit/queue.py
+++ b/event_people/broker/rabbit/queue.py
@@ -52,8 +52,6 @@ class Queue:
             arguments={'x-dead-letter-exchange': dlx_name},
         )
 
-        print(routing_key)
-
         self._channel.queue_bind(
             exchange=self.TOPIC_NAME, queue=queue_name, routing_key=routing_key)
 
@@ -86,10 +84,15 @@ class Queue:
         continuous, callback, final_method_name, queue_name, retry_params = args
         event_name = delivery_info.routing_key
 
-        # Read retry count from AMQP header
+        # Read retry count from AMQP header — pika may deliver the value as int,
+        # float, or str depending on the AMQP type tag used by the publisher.
         retry_count = 0
         if properties and properties.headers:
-            retry_count = int(properties.headers.get('x-event-people-retries', 0))
+            raw = properties.headers.get('x-event-people-retries', 0)
+            try:
+                retry_count = max(0, int(float(raw)))
+            except (TypeError, ValueError):
+                retry_count = 0
 
         event = Event(event_name, payload, retry_count=retry_count)
 
@@ -104,8 +107,8 @@ class Queue:
             max_retries=max_retries,
             delay_strategy=delay_strategy,
             retry_count=retry_count,
+            body=payload,
         )
-        context._body = payload
         context.dlq_name = retry_params.get('dlq_name', f'{self.APP_NAME.lower()}_dlq')
 
         try:

--- a/event_people/broker/rabbit/queue.py
+++ b/event_people/broker/rabbit/queue.py
@@ -4,11 +4,12 @@ from functools import partial
 from event_people.event import Event
 from .context import RabbitContext
 
+
 class Queue:
     TOPIC_NAME = os.environ['RABBIT_EVENT_PEOPLE_TOPIC_NAME']
     APP_NAME = os.environ['RABBIT_EVENT_PEOPLE_APP_NAME']
 
-    """ Queue wrappper for python user"""
+    """ Queue wrapper for python user"""
     def __init__(self, channel):
         if channel is None:
             raise ValueError("Channel must be defined.")
@@ -17,36 +18,95 @@ class Queue:
         self._channel = channel
 
     @classmethod
-    def subscribe(cls, channel, event_name, continuous, callback, final_method_name=None):
-        cls(channel).isubscribe(event_name, continuous, callback, final_method_name)
+    def subscribe(cls, channel, event_name, continuous, callback,
+                  final_method_name=None, retry_params=None):
+        cls(channel).isubscribe(event_name, continuous, callback,
+                                final_method_name, retry_params)
 
-    def isubscribe(self, event_name, continuous, callback, final_method_name=None):
-        queue_name = self._define_queue(event_name)
+    def isubscribe(self, event_name, continuous, callback,
+                   final_method_name=None, retry_params=None):
+        retry_params = retry_params or {}
+        queue_name = self._define_queue(event_name, retry_params)
 
-        on_message_callback = partial(self._callback, args=(continuous, callback, final_method_name))
+        on_message_callback = partial(
+            self._callback,
+            args=(continuous, callback, final_method_name, queue_name, retry_params),
+        )
         self._channel.basic_consume(
             queue=queue_name, on_message_callback=on_message_callback, auto_ack=False)
 
-    def _define_queue(self, event_name):
+    def _define_queue(self, event_name, retry_params=None):
+        retry_params = retry_params or {}
         routing_key = '.'.join(event_name.split('.')[0:4])
-
         queue_name = self._queue_name(routing_key)
+
+        app_name = self.APP_NAME.lower()
+        dlx_name = f'{app_name}_dlx'
+        dlq_name = retry_params.get('dlq_name', f'{app_name}_dlq')
+
+        # Declare the main queue with dead-letter-exchange pointing to DLX
         self._channel.queue_declare(
-            queue_name, durable=True, exclusive=False)
+            queue_name,
+            durable=True,
+            exclusive=False,
+            arguments={'x-dead-letter-exchange': dlx_name},
+        )
 
         print(routing_key)
 
         self._channel.queue_bind(
             exchange=self.TOPIC_NAME, queue=queue_name, routing_key=routing_key)
 
+        # Declare DLX exchange (fanout, durable) — idempotent
+        self._channel.exchange_declare(
+            exchange=dlx_name,
+            exchange_type='fanout',
+            durable=True,
+        )
+
+        # Declare DLQ and bind to DLX — idempotent
+        self._channel.queue_declare(dlq_name, durable=True, exclusive=False)
+        self._channel.queue_bind(exchange=dlx_name, queue=dlq_name, routing_key='')
+
+        # Declare retry queue — messages expire back to the main queue via DLX
+        retry_queue_name = f'{queue_name}_retry'
+        self._channel.queue_declare(
+            retry_queue_name,
+            durable=True,
+            exclusive=False,
+            arguments={
+                'x-dead-letter-exchange': '',
+                'x-dead-letter-routing-key': queue_name,
+            },
+        )
+
         return queue_name
 
     def _callback(self, channel, delivery_info, properties, payload, args):
-        continuous, callback, final_method_name = args
+        continuous, callback, final_method_name, queue_name, retry_params = args
         event_name = delivery_info.routing_key
 
-        event = Event(event_name, payload)
-        context = RabbitContext(channel, delivery_info)
+        # Read retry count from AMQP header
+        retry_count = 0
+        if properties and properties.headers:
+            retry_count = int(properties.headers.get('x-event-people-retries', 0))
+
+        event = Event(event_name, payload, retry_count=retry_count)
+
+        max_retries = retry_params.get('max_retries', 3)
+        delay_strategy = retry_params.get('delay_strategy', 'exponential')
+
+        context = RabbitContext(
+            channel=channel,
+            delivery_info=delivery_info,
+            properties=properties,
+            queue_name=queue_name,
+            max_retries=max_retries,
+            delay_strategy=delay_strategy,
+            retry_count=retry_count,
+        )
+        context._body = payload
+        context.dlq_name = retry_params.get('dlq_name', f'{self.APP_NAME.lower()}_dlq')
 
         try:
             param_count = len(inspect.signature(callback).parameters)

--- a/event_people/broker/rabbit/retry_manager.py
+++ b/event_people/broker/rabbit/retry_manager.py
@@ -1,0 +1,19 @@
+import os
+
+
+class RetryManager:
+    INITIAL_DELAY = int(os.environ.get('RABBIT_EVENT_PEOPLE_RETRY_TTL_MS', 1000))
+    MAX_DELAY = 600_000
+
+    def __init__(self, max_attempts, delay_strategy='exponential'):
+        self.max_attempts = max_attempts
+        self.delay_strategy = delay_strategy
+
+    def should_retry(self, retry_count):
+        return retry_count < self.max_attempts
+
+    def get_next_delay(self, retry_count):
+        if self.delay_strategy == 'fixed':
+            return self.INITIAL_DELAY
+        # exponential: initialDelay * (5 ^ retry_count)
+        return min(self.INITIAL_DELAY * (5 ** retry_count), self.MAX_DELAY)

--- a/event_people/broker/rabbit_broker.py
+++ b/event_people/broker/rabbit_broker.py
@@ -19,8 +19,9 @@ class RabbitBroker(Base):
         except (AMQPConnectionError, StreamLostError) as error:
             return self._channel()
 
-    def consume(self, event_name, callback, final_method_name=None, continuous=True):
-        Queue.subscribe(self.get_connection(), event_name, continuous, callback, final_method_name)
+    def consume(self, event_name, callback, final_method_name=None, continuous=True, retry_params=None):
+        Queue.subscribe(self.get_connection(), event_name, continuous, callback,
+                        final_method_name, retry_params=retry_params)
 
     def produce(self, events):
         events = events if hasattr(events, "__len__") else [events]

--- a/event_people/config.py
+++ b/event_people/config.py
@@ -9,6 +9,9 @@ class Config:
     TOPIC_NAME = os.environ['RABBIT_EVENT_PEOPLE_TOPIC_NAME']
     VHOST = os.environ['RABBIT_EVENT_PEOPLE_VHOST']
     RABBIT_URL = os.environ['RABBIT_URL']
+    MAX_ATTEMPTS = int(os.environ.get('RABBIT_EVENT_PEOPLE_MAX_RETRIES', 3))
+    DELAY_STRATEGY = os.environ.get('RABBIT_EVENT_PEOPLE_DELAY_STRATEGY', 'exponential')
+    DLQ_NAME = f"{os.environ['RABBIT_EVENT_PEOPLE_APP_NAME']}_dlq"
     broker = None
 
     @classmethod
@@ -16,3 +19,11 @@ class Config:
         cls.broker = cls.broker or RabbitBroker()
 
         return cls.broker
+
+    @classmethod
+    def get_retry_config(cls):
+        return {
+            'max_attempts': cls.MAX_ATTEMPTS,
+            'delay_strategy': cls.DELAY_STRATEGY,
+            'dlq_name': cls.DLQ_NAME,
+        }

--- a/event_people/event.py
+++ b/event_people/event.py
@@ -36,7 +36,7 @@ class Event(object):
     """
     APP_NAME = os.environ['RABBIT_EVENT_PEOPLE_APP_NAME']
 
-    def __init__(self, name, body, schema_version = 1.0):
+    def __init__(self, name, body, schema_version = 1.0, retry_count = 0):
         self.name = self.__fix_name__(name)
         self.__generate_header__(schema_version)
         body_dict = body
@@ -47,6 +47,10 @@ class Event(object):
         self.header.schema_version = schema_version
 
         self.body = body_dict if 'body' not in body_dict else body_dict['body']
+        self.retry_count = retry_count
+
+    def increment_retry_count(self):
+        self.retry_count += 1
 
 
     def __generate_header__(self, schema_version):

--- a/event_people/listener.py
+++ b/event_people/listener.py
@@ -2,7 +2,12 @@ from event_people.config import Config
 
 class Listener:
     @staticmethod
-    def on(event_name, callback = None):
+    def on(event_name, callback=None, max_attempts=None, delay_strategy=None, dlq_name=None):
+        retry_config = Config.get_retry_config()
+        resolved_max_attempts = max_attempts if max_attempts is not None else retry_config['max_attempts']
+        resolved_delay_strategy = delay_strategy if delay_strategy is not None else retry_config['delay_strategy']
+        resolved_dlq_name = dlq_name if dlq_name is not None else retry_config['dlq_name']
+
         broker_callback = callback if callback else Listener.basic_callback
         queue_names = [event_name]
         broker = Config.get_broker()
@@ -11,8 +16,14 @@ class Listener:
         if len(event_name.split('.')) == 3:
             queue_names = [f'{event_name}.all', f'{event_name}.{Config.APP_NAME}']
 
+        retry_params = {
+            'max_retries': resolved_max_attempts,
+            'delay_strategy': resolved_delay_strategy,
+            'dlq_name': resolved_dlq_name,
+        }
+
         for queue_name in queue_names:
-            broker.consume(queue_name, broker_callback, False)
+            broker.consume(queue_name, broker_callback, False, retry_params=retry_params)
 
         try:
             channel.start_consuming()

--- a/event_people/listener.py
+++ b/event_people/listener.py
@@ -23,7 +23,7 @@ class Listener:
         }
 
         for queue_name in queue_names:
-            broker.consume(queue_name, broker_callback, False, retry_params=retry_params)
+            broker.consume(queue_name, broker_callback, continuous=False, retry_params=retry_params)
 
         try:
             channel.start_consuming()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "event_people"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Pin People", email="tech@pinpeople.com.br" },
 ]


### PR DESCRIPTION
## Summary

- Implements `RetryManager` with exponential (default) and fixed backoff strategies
- Adds DLX/DLQ/retry queue topology declared on subscribe (idempotent)
- `RabbitContext.fail()` now retries via per-message TTL on a `_retry` queue; exhausted messages are nack'd to DLQ
- `Event.retry_count` populated from `x-event-people-retries` AMQP header; `increment_retry_count()` added
- `Config` gains `MAX_ATTEMPTS`, `DELAY_STRATEGY`, `DLQ_NAME`, and `get_retry_config()`
- `Listener.on()` extended with optional `max_attempts`, `delay_strategy`, `dlq_name` params
- Version bumped `0.1.1` → `0.1.2` in `pyproject.toml` and `.event_people.yml`
- All retry-related pending items moved to `implemented` in `.event_people.yml`

Implements RetryManager, exponential/fixed backoff, DLX/DLQ topology per spec v1.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic retry handling for failed events with configurable maximum attempts and delay strategies (fixed or exponential backoff)
  * Dead-letter queue support to handle events that cannot be processed after retries are exhausted
  * Event processing now includes configurable retry parameters

* **Chores**
  * Version updated to 0.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->