### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "event_people"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
   { name="Pin People", email="tech@pinpeople.com.br" },
 ]


### PR DESCRIPTION
Patch release with fix for nack(requeue=false) fallback on retry-publish failure (spec v1.1.1).