### PR TITLE
feat(spec v1.2.0): programmatic retry config + BaseListener DSL

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -27,7 +27,7 @@ implemented:
   - "Config.dlqName"
   - "Config.getRetryConfig"
   - "Config.configure"
-  - "Listener.on (signature: on(eventName, callback) — v1.2.0)"
+  - "Listener.on (signature: on(event_name, callback) — v1.2.0)"
   - "BaseListener class-level retry attributes: maxAttempts, initialDelay, delayStrategy, dlqName"
   - "BaseListener.context (instance accessor, injected by Queue._callback)"
   - "BaseListener.callback (signature: callback(function, event, context) — v1.2.0, documented as DEV-PY-002)"

--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
-spec_version: "1.1.1"
-implementation_version: "0.1.3"
+spec_version: "1.2.0"
+implementation_version: "0.2.0"
 language: python
 package: "event_people (PyPI)"
 status: stable
@@ -22,19 +22,43 @@ implemented:
   - "Event.retryCount"
   - "Event.incrementRetryCount"
   - "Config.maxAttempts"
+  - "Config.initialDelay"
   - "Config.delayStrategy"
   - "Config.dlqName"
   - "Config.getRetryConfig"
-  - "Listener.on (retry params: maxAttempts, delayStrategy, dlqName)"
+  - "Config.configure"
+  - "Listener.on (signature: on(eventName, callback) — v1.2.0)"
+  - "BaseListener class-level retry attributes: maxAttempts, initialDelay, delayStrategy, dlqName"
+  - "BaseListener.context (instance accessor, injected by Queue._callback)"
+  - "BaseListener.callback (signature: callback(function, event, context) — v1.2.0, documented as DEV-PY-002)"
   - "Context.maxRetries"
   - "Context.isLastRetry"
   - "RabbitContext.maxRetries"
   - "RabbitContext.isLastRetry"
   - "RabbitContext.dlqName"
+  - "Event.has_body"
+  - "Event.has_name"
+  - "Daemon.stop"
+  - "Daemon.bind_signals"
+  - "BaseBroker.close_connection"
+  - "RabbitBroker.close_connection"
 
 # Spec components not yet implemented (pending in spec too)
 pending:
   - "Config.fullUrl (built per-request in RabbitBroker._full_url instead)"
 
 # Structural or naming departures from the spec
-deviations: []
+deviations:
+  - id: DEV-PY-002
+    component: BaseListener
+    method: callback
+    spec_signature: "callback(function, event)"
+    impl_signature: "callback(function, event, context=None)"
+    reason: >
+      Queue._callback injects the RabbitContext as the third positional argument so that
+      BaseListener.callback can set self.context on the instance before dispatching to the
+      handler method. The extra parameter is optional (defaults to None) and does not break
+      callers that pass only (function, event). Bringing the signature to spec would require
+      a separate context-injection mechanism (e.g. a thread-local or a dedicated inject method)
+      and is deferred to a future minor release.
+    status: documented

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ export RABBIT_URL='amqp://guest:guest@localhost:5672'
 export RABBIT_EVENT_PEOPLE_APP_NAME='service_name'
 export RABBIT_EVENT_PEOPLE_VHOST='event_people'
 export RABBIT_EVENT_PEOPLE_TOPIC_NAME='event_people'
-````
+```
+
+> **Note:** `RABBIT_EVENT_PEOPLE_MAX_RETRIES` and `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS`
+> were removed in v1.2.0. Retry settings are now configured via `Config.configure()`
+> or per-listener class attributes — see the [Retry and DLQ](#retry-and-dead-letter-queue-dlq) section.
 
 ## Usage
 
@@ -231,18 +235,53 @@ Daemon.start()
 
 ## Retry and Dead Letter Queue (DLQ)
 
-### Environment variables
+### Configuration
 
-| Variable | Description | Default |
-|---|---|---|
-| `RABBIT_EVENT_PEOPLE_MAX_RETRIES` | Max retry attempts before dead-lettering | `3` |
-| `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` | Base delay in ms for retry backoff | `1000` |
+Retry behaviour is configured in code — the old env vars
+`RABBIT_EVENT_PEOPLE_MAX_RETRIES` and `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` were
+removed in v1.2.0.
+
+**Global defaults via `Config.configure()`** (optional — hardcoded defaults apply when not called):
+
+```python
+from event_people import Config
+
+Config.configure({
+    'max_attempts': 5,       # default: 3
+    'initial_delay': 2000,   # base delay in ms, default: 1000
+    'delay_strategy': 'exponential',  # 'exponential' or 'fixed', default: 'exponential'
+    'dlq_name': 'my_dlq',   # default: '{appName}_dlq'
+})
+```
+
+**Per-listener overrides** via class attributes (override Config defaults for that specific listener):
+
+```python
+from event_people import BaseListener
+
+class OrderListener(BaseListener):
+    max_attempts = 5
+    initial_delay = 2000
+    delay_strategy = 'exponential'
+
+    def handle(self, event):
+        try:
+            process(event)
+            self.success()
+        except Exception:
+            if self.context.is_last_retry:
+                print("Final attempt failed, sending to DLQ")
+            self.fail()
+
+OrderListener.bind_event('order.service.created', 'handle')
+```
 
 ### How it works
 
 On `context.fail()`:
-- If retries remain → message is published to `{queue}_retry` with exponential backoff delay, then acked
+- If retries remain → message is published to `{queue}_retry` with backoff delay, then acked
 - If retries exhausted → nacked to DLQ via RabbitMQ DLX
+- If publish to retry queue fails (broker down) → nacked to DLQ (never requeued to avoid infinite loops)
 
 On `context.reject()` → nacked directly to DLQ (no retries)
 
@@ -258,7 +297,7 @@ On `context.reject()` → nacked directly to DLQ (no retries)
 | DLQ | `{appName}_dlq` | Final resting place for failed messages |
 | Retry queue | `{queue_name}_retry` | Holds messages until backoff delay expires |
 
-### Usage
+### Usage with `Listener.on`
 
 ```python
 from event_people import Listener, Event
@@ -278,15 +317,7 @@ def handle_event(event: Event, context):
             print("Final attempt failed, sending to DLQ")
         context.fail()     # → retry queue (or DLQ if exhausted)
 
-# Per-listener retry config (overrides env var defaults)
-Listener.on("order.service.created", handle_event,
-            max_attempts=5,
-            delay_strategy="exponential")
-
-# Fixed delay
-Listener.on("user.service.updated", handle_event,
-            max_attempts=3,
-            delay_strategy="fixed")
+Listener.on("order.service.created", handle_event)
 ```
 
 ## Development

--- a/event_people/broker/base.py
+++ b/event_people/broker/base.py
@@ -18,3 +18,6 @@ class Base:
     @classmethod
     def produce(cls, events):
         cls().produce(events)
+
+    def close_connection(self):
+        raise NotImplementedError('Must be implemented') #pragma: no cover

--- a/event_people/broker/rabbit/context.py
+++ b/event_people/broker/rabbit/context.py
@@ -5,15 +5,17 @@ from event_people.broker.rabbit.retry_manager import RetryManager
 class RabbitContext:
     """ Queue wrapper for python user"""
     def __init__(self, channel, delivery_info, properties=None, queue_name=None,
-                 max_retries=3, delay_strategy='exponential', retry_count=0, body=None):
+                 max_retries=3, delay_strategy='exponential', initial_delay=1000,
+                 retry_count=0, body=None):
         self.channel = channel
         self.delivery_info = delivery_info
         self.properties = properties
         self.queue_name = queue_name
         self.max_retries = max_retries
         self.delay_strategy = delay_strategy
+        self.initial_delay = initial_delay
         self.retry_count = retry_count
-        self._retry_manager = RetryManager(max_retries, delay_strategy)
+        self._retry_manager = RetryManager(max_retries, delay_strategy, initial_delay)
         self.dlq_name = None
         self._body = body if body is not None else b''
 

--- a/event_people/broker/rabbit/queue.py
+++ b/event_people/broker/rabbit/queue.py
@@ -98,6 +98,7 @@ class Queue:
 
         max_retries = retry_params.get('max_retries', 3)
         delay_strategy = retry_params.get('delay_strategy', 'exponential')
+        initial_delay = retry_params.get('initial_delay', 1000)
 
         context = RabbitContext(
             channel=channel,
@@ -106,20 +107,25 @@ class Queue:
             queue_name=queue_name,
             max_retries=max_retries,
             delay_strategy=delay_strategy,
+            initial_delay=initial_delay,
             retry_count=retry_count,
             body=payload,
         )
         context.dlq_name = retry_params.get('dlq_name', f'{self.APP_NAME.lower()}_dlq')
 
-        try:
-            param_count = len(inspect.signature(callback).parameters)
-        except (ValueError, TypeError):
-            param_count = 2
-
-        if param_count >= 3:
-            callback(event, context, final_method_name)
+        if final_method_name is not None:
+            # Dispatch via BaseListener.callback(function, event, context) — v1.2.0
+            callback(final_method_name, event, context)
         else:
-            callback(event, context)
+            try:
+                param_count = len(inspect.signature(callback).parameters)
+            except (ValueError, TypeError):
+                param_count = 2
+
+            if param_count >= 3:
+                callback(event, context, final_method_name)
+            else:
+                callback(event, context)
 
         if not continuous:
             channel.stop_consuming()

--- a/event_people/broker/rabbit/retry_manager.py
+++ b/event_people/broker/rabbit/retry_manager.py
@@ -1,19 +1,16 @@
-import os
-
-
 class RetryManager:
-    INITIAL_DELAY = int(os.environ.get('RABBIT_EVENT_PEOPLE_RETRY_TTL_MS', 1000))
     MAX_DELAY = 600_000
 
-    def __init__(self, max_attempts, delay_strategy='exponential'):
+    def __init__(self, max_attempts, delay_strategy='exponential', initial_delay=1000):
         self.max_attempts = max_attempts
         self.delay_strategy = delay_strategy
+        self.initial_delay = initial_delay
 
     def should_retry(self, retry_count):
         return retry_count < self.max_attempts
 
     def get_next_delay(self, retry_count):
         if self.delay_strategy == 'fixed':
-            return self.INITIAL_DELAY
-        # exponential: initialDelay * (5 ^ retry_count)
-        return min(self.INITIAL_DELAY * (5 ** retry_count), self.MAX_DELAY)
+            return self.initial_delay
+        # exponential: initialDelay * (5 ^ retry_count), capped at maxDelay
+        return min(self.initial_delay * (5 ** retry_count), self.MAX_DELAY)

--- a/event_people/broker/rabbit/topic.py
+++ b/event_people/broker/rabbit/topic.py
@@ -28,6 +28,6 @@ class Topic:
 
     def iproduce(self, event):
         topic = self.iget_topic()
-        body = json.dumps({'body': event.body, 'headers': event.header.__dict__}, indent=2).encode('utf-8')
+        body = json.dumps({'body': event.body, 'headers': event.header.to_dict()}, indent=2).encode('utf-8')
 
         topic.basic_publish(exchange=self.TOPIC_NAME, routing_key=event.name, body=body)

--- a/event_people/broker/rabbit_broker.py
+++ b/event_people/broker/rabbit_broker.py
@@ -42,5 +42,10 @@ class RabbitBroker(Base):
     def _parameters(self):
         return pika.connection.URLParameters(self._full_url())
 
+    def close_connection(self):
+        """Close the RabbitMQ connection if open."""
+        if self.connection and not self.connection.is_closed:
+            self.connection.close()
+
     def _full_url(self):
         return f'{self.RABBIT_URL}/{self.VHOST}'

--- a/event_people/config.py
+++ b/event_people/config.py
@@ -9,10 +9,40 @@ class Config:
     TOPIC_NAME = os.environ['RABBIT_EVENT_PEOPLE_TOPIC_NAME']
     VHOST = os.environ['RABBIT_EVENT_PEOPLE_VHOST']
     RABBIT_URL = os.environ['RABBIT_URL']
-    MAX_ATTEMPTS = int(os.environ.get('RABBIT_EVENT_PEOPLE_MAX_RETRIES', 3))
-    DELAY_STRATEGY = os.environ.get('RABBIT_EVENT_PEOPLE_DELAY_STRATEGY', 'exponential')
-    DLQ_NAME = f"{os.environ['RABBIT_EVENT_PEOPLE_APP_NAME']}_dlq"
+
+    # Retry defaults — hardcoded, overridable via configure() or BaseListener class attributes.
+    # Env vars RABBIT_EVENT_PEOPLE_MAX_RETRIES and RABBIT_EVENT_PEOPLE_RETRY_TTL_MS were
+    # removed in spec v1.2.0.
+    MAX_ATTEMPTS = 3
+    INITIAL_DELAY = 1000
+    DELAY_STRATEGY = 'exponential'
+    DLQ_NAME = None  # Defaults to '{appName}_dlq' when not set
+
     broker = None
+
+    @classmethod
+    def configure(cls, options=None):
+        """Set global retry defaults in code.
+
+        Options (all optional):
+          max_attempts   — maximum retry attempts (default: 3)
+          initial_delay  — base delay in ms for retry backoff (default: 1000)
+          delay_strategy — 'exponential' or 'fixed' (default: 'exponential')
+          dlq_name       — DLQ name (default: '{appName}_dlq')
+
+        Connection attributes (app_name, url, vhost, topic) are always read from
+        environment variables and cannot be overridden here.
+        """
+        if options is None:
+            return
+        if 'max_attempts' in options:
+            cls.MAX_ATTEMPTS = options['max_attempts']
+        if 'initial_delay' in options:
+            cls.INITIAL_DELAY = options['initial_delay']
+        if 'delay_strategy' in options:
+            cls.DELAY_STRATEGY = options['delay_strategy']
+        if 'dlq_name' in options:
+            cls.DLQ_NAME = options['dlq_name']
 
     @classmethod
     def get_broker(cls):
@@ -22,8 +52,10 @@ class Config:
 
     @classmethod
     def get_retry_config(cls):
+        """Return the active global retry configuration."""
         return {
             'max_attempts': cls.MAX_ATTEMPTS,
+            'initial_delay': cls.INITIAL_DELAY,
             'delay_strategy': cls.DELAY_STRATEGY,
-            'dlq_name': cls.DLQ_NAME,
+            'dlq_name': cls.DLQ_NAME if cls.DLQ_NAME is not None else f'{cls.APP_NAME}_dlq',
         }

--- a/event_people/config.py
+++ b/event_people/config.py
@@ -36,13 +36,25 @@ class Config:
         if options is None:
             return
         if 'max_attempts' in options:
-            cls.MAX_ATTEMPTS = options['max_attempts']
+            val = options['max_attempts']
+            if not isinstance(val, int) or val < 1:
+                raise ValueError("max_attempts must be an integer >= 1")
+            cls.MAX_ATTEMPTS = val
         if 'initial_delay' in options:
-            cls.INITIAL_DELAY = options['initial_delay']
+            val = options['initial_delay']
+            if not isinstance(val, int) or val < 0:
+                raise ValueError("initial_delay must be an integer >= 0")
+            cls.INITIAL_DELAY = val
         if 'delay_strategy' in options:
-            cls.DELAY_STRATEGY = options['delay_strategy']
+            val = options['delay_strategy']
+            if val not in ('exponential', 'fixed'):
+                raise ValueError("delay_strategy must be 'exponential' or 'fixed'")
+            cls.DELAY_STRATEGY = val
         if 'dlq_name' in options:
-            cls.DLQ_NAME = options['dlq_name']
+            val = options['dlq_name']
+            if val is not None and (not isinstance(val, str) or val == ''):
+                raise ValueError("dlq_name must be a non-empty string or None")
+            cls.DLQ_NAME = val
 
     @classmethod
     def get_broker(cls):

--- a/event_people/daemon.py
+++ b/event_people/daemon.py
@@ -1,9 +1,14 @@
+import signal
+import sys
+
 from event_people.config import Config
 from event_people.listeners.listener_manager import ListenerManager
 
 class Daemon:
     @classmethod
     def start(cls):
+        cls.bind_signals()
+
         channel = Config.get_broker().get_connection()
 
         ListenerManager.bind_all_listeners()
@@ -12,3 +17,17 @@ class Daemon:
             channel.start_consuming()
         except KeyboardInterrupt: #pragma: no cover
             channel.stop_consuming()##pragma: no cover
+
+    @classmethod
+    def stop(cls):
+        """Close broker connection and terminate the process."""
+        broker = Config.broker
+        if broker is not None:
+            broker.close_connection()
+        sys.exit(0)
+
+    @classmethod
+    def bind_signals(cls):
+        """Trap SIGTERM and SIGINT for graceful shutdown."""
+        signal.signal(signal.SIGTERM, lambda signum, frame: cls.stop())
+        signal.signal(signal.SIGINT, lambda signum, frame: cls.stop())

--- a/event_people/daemon.py
+++ b/event_people/daemon.py
@@ -22,9 +22,11 @@ class Daemon:
     def stop(cls):
         """Close broker connection and terminate the process."""
         broker = Config.broker
-        if broker is not None:
-            broker.close_connection()
-        sys.exit(0)
+        try:
+            if broker is not None:
+                broker.close_connection()
+        finally:
+            sys.exit(0)
 
     @classmethod
     def bind_signals(cls):

--- a/event_people/event.py
+++ b/event_people/event.py
@@ -53,8 +53,8 @@ class Event(object):
         self.retry_count += 1
 
     def has_body(self):
-        """Return True when the event body is a non-empty dict."""
-        return bool(self.body)
+        """Return True when the event body is not None."""
+        return self.body is not None
 
     def has_name(self):
         """Return True when the event name is a non-empty string."""

--- a/event_people/event.py
+++ b/event_people/event.py
@@ -41,12 +41,14 @@ class Event(object):
         self.__generate_header__(schema_version)
         body_dict = body
 
-        if not isinstance(body, dict):
+        if body is None:
+            body_dict = None
+        elif not isinstance(body, dict):
             body_dict = ast.literal_eval(body.decode('utf-8'))
 
         self.header.schema_version = schema_version
 
-        self.body = body_dict if 'body' not in body_dict else body_dict['body']
+        self.body = None if body_dict is None else (body_dict if 'body' not in body_dict else body_dict['body'])
         self.retry_count = retry_count
 
     def increment_retry_count(self):

--- a/event_people/event.py
+++ b/event_people/event.py
@@ -52,6 +52,13 @@ class Event(object):
     def increment_retry_count(self):
         self.retry_count += 1
 
+    def has_body(self):
+        """Return True when the event body is a non-empty dict."""
+        return bool(self.body)
+
+    def has_name(self):
+        """Return True when the event name is a non-empty string."""
+        return bool(self.name)
 
     def __generate_header__(self, schema_version):
         resource, origin, action, destination = self.name.split(".")

--- a/event_people/listener.py
+++ b/event_people/listener.py
@@ -2,11 +2,17 @@ from event_people.config import Config
 
 class Listener:
     @staticmethod
-    def on(event_name, callback=None, max_attempts=None, delay_strategy=None, dlq_name=None):
+    def on(event_name, callback=None):
+        """Subscribe to a specific event or pattern.
+
+        When eventName has 3 parts, the lib subscribes to both the .all and
+        .{appName} variants automatically (using ONE queue with TWO bindings).
+
+        Retry configuration is resolved from Config defaults (set via
+        Config.configure()). To override per-listener, use a BaseListener
+        subclass with class-level retry attributes instead.
+        """
         retry_config = Config.get_retry_config()
-        resolved_max_attempts = max_attempts if max_attempts is not None else retry_config['max_attempts']
-        resolved_delay_strategy = delay_strategy if delay_strategy is not None else retry_config['delay_strategy']
-        resolved_dlq_name = dlq_name if dlq_name is not None else retry_config['dlq_name']
 
         broker_callback = callback if callback else Listener.basic_callback
         queue_names = [event_name]
@@ -17,9 +23,10 @@ class Listener:
             queue_names = [f'{event_name}.all', f'{event_name}.{Config.APP_NAME}']
 
         retry_params = {
-            'max_retries': resolved_max_attempts,
-            'delay_strategy': resolved_delay_strategy,
-            'dlq_name': resolved_dlq_name,
+            'max_retries': retry_config['max_attempts'],
+            'initial_delay': retry_config['initial_delay'],
+            'delay_strategy': retry_config['delay_strategy'],
+            'dlq_name': retry_config['dlq_name'],
         }
 
         for queue_name in queue_names:

--- a/event_people/listeners/base_listener.py
+++ b/event_people/listeners/base_listener.py
@@ -2,8 +2,50 @@ from event_people.config import Config
 from event_people.listeners.listener_manager import ListenerManager
 
 class BaseListener:
+    """Base class for user-defined listener classes.
+
+    Class-level retry attributes (all optional — fall back to Config defaults):
+      max_attempts   — maximum retry attempts for this listener
+      initial_delay  — base retry delay in ms for this listener
+      delay_strategy — 'exponential' or 'fixed'
+      dlq_name       — DLQ name for this listener
+
+    Example::
+
+        class OrderListener(BaseListener):
+            max_attempts = 5
+            initial_delay = 2000
+            delay_strategy = 'exponential'
+
+            def handle(self, event):
+                process(event)
+                self.success()
+
+        OrderListener.bind_event('order.service.created', 'handle')
+    """
+
+    # Class-level retry overrides — subclasses may declare these.
+    # Value of None means "use Config default".
+    max_attempts = None
+    initial_delay = None
+    delay_strategy = None
+    dlq_name = None
+
     def __init__(self, context):
+        self.context = context
+        # Keep backward-compatible private alias
         self._context = context
+
+    @classmethod
+    def _resolve_retry_params(cls):
+        """Resolve retry config: listener class attributes > Config defaults."""
+        global_config = Config.get_retry_config()
+        return {
+            'max_retries': cls.max_attempts if cls.max_attempts is not None else global_config['max_attempts'],
+            'initial_delay': cls.initial_delay if cls.initial_delay is not None else global_config['initial_delay'],
+            'delay_strategy': cls.delay_strategy if cls.delay_strategy is not None else global_config['delay_strategy'],
+            'dlq_name': cls.dlq_name if cls.dlq_name is not None else global_config['dlq_name'],
+        }
 
     @classmethod
     def bind_event(cls, event_name, callback):
@@ -27,10 +69,19 @@ class BaseListener:
             )
 
     @classmethod
-    def callback(cls, event, context, final_method_name):
-        instance = cls(context)
-        method = getattr(instance, final_method_name)
+    def callback(cls, function, event, context=None):
+        """Wrap broker delivery into Event + Context and dispatch to user method.
 
+        Signature: ``callback(function, event, context)``
+          - function: name of the handler method to call on this listener instance
+          - event:    Event instance built from the broker delivery
+          - context:  RabbitContext instance (injected by Queue._callback). Also
+                      set as ``self.context`` on the listener instance before dispatch.
+
+        Retry config is resolved from: listener class attributes > Config defaults.
+        """
+        instance = cls(context)
+        method = getattr(instance, function)
         method(event)
 
     @classmethod

--- a/event_people/listeners/listener_manager.py
+++ b/event_people/listeners/listener_manager.py
@@ -13,7 +13,14 @@ class ListenerManager:
         broker = Config.get_broker()
 
         for listener in cls._listeners:
-            broker.consume(listener.event_name, listener.listener_class.callback, final_method_name=listener.callback)
+            # Resolve retry params from listener class attributes > Config defaults
+            retry_params = listener.listener_class._resolve_retry_params()
+            broker.consume(
+                listener.event_name,
+                listener.listener_class.callback,
+                final_method_name=listener.callback,
+                retry_params=retry_params,
+            )
 
 
 class ListenerConfiguration:

--- a/tests/broker/rabbit/test_context.py
+++ b/tests/broker/rabbit/test_context.py
@@ -1,5 +1,7 @@
 import mock
 from pika.spec import Basic
+import pika
+
 
 class TestContext:
 
@@ -23,3 +25,118 @@ class TestContext:
         delivery_tag = Basic.Deliver('consumer_tag_')
         context = Context(connection, delivery_tag)
         context.fail()
+
+    # --- v1.2.0 ---
+
+    @mock.patch('pika.BlockingConnection')
+    def test_context_accepts_initial_delay(self, connection, setup):
+        """RabbitContext must accept initial_delay param (v1.2.0)."""
+        from event_people.broker.rabbit.context import RabbitContext
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        ctx = RabbitContext(connection, delivery_tag, initial_delay=2000)
+        assert ctx.initial_delay == 2000
+
+    @mock.patch('pika.BlockingConnection')
+    def test_context_default_initial_delay(self, connection, setup):
+        """RabbitContext default initial_delay is 1000 ms."""
+        from event_people.broker.rabbit.context import RabbitContext
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        ctx = RabbitContext(connection, delivery_tag)
+        assert ctx.initial_delay == 1000
+
+    def test_is_last_retry_true_when_at_max(self, setup):
+        """is_last_retry == True when retry_count >= max_retries - 1."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        ctx = RabbitContext(channel, delivery_tag, max_retries=3, retry_count=2)
+        assert ctx.is_last_retry is True
+
+    def test_is_last_retry_false_when_under_max(self, setup):
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        ctx = RabbitContext(channel, delivery_tag, max_retries=3, retry_count=0)
+        assert ctx.is_last_retry is False
+
+    def test_fail_publishes_with_initial_delay_expiration(self, setup):
+        """fail() should publish with expiration = initial_delay * (5^retry_count)."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 1
+
+        ctx = RabbitContext(
+            channel, delivery_tag,
+            queue_name='test_queue',
+            max_retries=3,
+            initial_delay=2000,
+            delay_strategy='exponential',
+            retry_count=0,
+            body=b'{}',
+        )
+        ctx.fail()
+
+        # Should publish to retry queue with expiration = 2000 * 5^0 = 2000
+        channel.basic_publish.assert_called_once()
+        _, kwargs = channel.basic_publish.call_args
+        assert kwargs['properties'].expiration == '2000'
+
+    def test_fail_fixed_delay_uses_initial_delay(self, setup):
+        """fail() with fixed strategy should use initial_delay as the constant delay."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 1
+
+        ctx = RabbitContext(
+            channel, delivery_tag,
+            queue_name='test_queue',
+            max_retries=3,
+            initial_delay=500,
+            delay_strategy='fixed',
+            retry_count=0,
+            body=b'{}',
+        )
+        ctx.fail()
+
+        channel.basic_publish.assert_called_once()
+        _, kwargs = channel.basic_publish.call_args
+        assert kwargs['properties'].expiration == '500'
+
+    def test_fail_exhausted_retries_nacks_without_requeue(self, setup):
+        """fail() with retries exhausted must nack(requeue=False) — never requeue=True."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 99
+
+        ctx = RabbitContext(
+            channel, delivery_tag,
+            max_retries=3,
+            retry_count=3,  # exhausted
+            body=b'{}',
+        )
+        ctx.fail()
+
+        channel.basic_nack.assert_called_once_with(99, requeue=False)
+        channel.basic_publish.assert_not_called()
+
+    def test_fail_publish_error_nacks_without_requeue(self, setup):
+        """When publish fails, must nack(requeue=False) — not requeue=True (SOPHIA-1G)."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        channel.basic_publish.side_effect = Exception("broker down")
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 42
+
+        ctx = RabbitContext(
+            channel, delivery_tag,
+            queue_name='test_queue',
+            max_retries=3,
+            retry_count=0,
+            body=b'{}',
+        )
+        ctx.fail()
+
+        channel.basic_nack.assert_called_once_with(42, requeue=False)

--- a/tests/broker/rabbit/test_retry_manager.py
+++ b/tests/broker/rabbit/test_retry_manager.py
@@ -1,0 +1,62 @@
+"""Tests for RetryManager — spec v1.2.0: initial_delay is a constructor param
+(no longer sourced from RABBIT_EVENT_PEOPLE_RETRY_TTL_MS env var)."""
+
+import pytest
+
+
+class TestRetryManager:
+
+    def test_should_retry_when_under_max(self, setup):
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='exponential', initial_delay=1000)
+        assert rm.should_retry(0) is True
+        assert rm.should_retry(1) is True
+        assert rm.should_retry(2) is True
+
+    def test_should_not_retry_when_at_max(self, setup):
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='exponential', initial_delay=1000)
+        assert rm.should_retry(3) is False
+        assert rm.should_retry(4) is False
+
+    def test_exponential_delay_uses_initial_delay(self, setup):
+        """Exponential: initialDelay * (5 ^ retry_count)."""
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='exponential', initial_delay=1000)
+        assert rm.get_next_delay(0) == 1000      # 1000 * 5^0 = 1000
+        assert rm.get_next_delay(1) == 5000      # 1000 * 5^1 = 5000
+        assert rm.get_next_delay(2) == 25000     # 1000 * 5^2 = 25000
+
+    def test_exponential_delay_custom_initial(self, setup):
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='exponential', initial_delay=500)
+        assert rm.get_next_delay(0) == 500       # 500 * 5^0
+        assert rm.get_next_delay(1) == 2500      # 500 * 5^1
+
+    def test_exponential_delay_capped_at_max_delay(self, setup):
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='exponential', initial_delay=1000)
+        # 1000 * 5^10 >> 600_000 — should be capped
+        assert rm.get_next_delay(10) == 600_000
+
+    def test_fixed_delay_constant(self, setup):
+        """Fixed strategy returns initial_delay regardless of retry count."""
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='fixed', initial_delay=2000)
+        assert rm.get_next_delay(0) == 2000
+        assert rm.get_next_delay(1) == 2000
+        assert rm.get_next_delay(5) == 2000
+
+    def test_fixed_delay_default_initial(self, setup):
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='fixed')
+        assert rm.get_next_delay(0) == 1000
+
+    def test_no_env_var_dependency(self, setup, monkeypatch):
+        """RetryManager must NOT read RABBIT_EVENT_PEOPLE_RETRY_TTL_MS — removed in v1.2.0."""
+        import os
+        monkeypatch.delenv('RABBIT_EVENT_PEOPLE_RETRY_TTL_MS', raising=False)
+        from event_people.broker.rabbit.retry_manager import RetryManager
+        rm = RetryManager(max_attempts=3, delay_strategy='exponential', initial_delay=3000)
+        # Should use the constructor arg, not any env var
+        assert rm.get_next_delay(0) == 3000

--- a/tests/broker/rabbit/test_topic.py
+++ b/tests/broker/rabbit/test_topic.py
@@ -1,6 +1,7 @@
+import json
 import pika
 import pytest
-from mock import patch
+from mock import patch, call
 
 
 class TestTopic:
@@ -39,3 +40,44 @@ class TestTopic:
             body = { 'amount': 350, 'name': 'George' }
             event = Event(name='resource.custom.pay', body=body)
             Topic.produce(channel=None, event=event)
+
+    def test_produce_uses_camelcase_header_keys(self, setup):
+        """BUG-PY-001: Topic.produce must publish camelCase JSON keys, not snake_case.
+
+        Spec requires headers JSON keys to be camelCase (appName, schemaVersion).
+        Previously event.header.__dict__ emitted snake_case (app_name, schema_version).
+        """
+        from event_people import RabbitBroker, Event, Topic
+
+        body = {'amount': 10}
+        event = Event(name='resource.custom.pay', body=body)
+
+        published_bodies = []
+
+        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+            rabbit = RabbitBroker()
+            channel = rabbit.get_connection()
+
+            # Capture the body argument passed to basic_publish
+            original_publish = channel.basic_publish
+            def capturing_publish(**kwargs):
+                published_bodies.append(kwargs.get('body', b''))
+            channel.basic_publish = capturing_publish
+
+            Topic.produce(channel=channel, event=event)
+
+        assert len(published_bodies) == 1, "basic_publish should have been called once"
+        payload = json.loads(published_bodies[0].decode('utf-8'))
+        headers = payload['headers']
+
+        # camelCase keys must be present
+        assert 'appName' in headers, f"'appName' missing from headers: {list(headers.keys())}"
+        assert 'schemaVersion' in headers, f"'schemaVersion' missing from headers: {list(headers.keys())}"
+
+        # snake_case keys must NOT be present (this was the bug)
+        assert 'app_name' not in headers, "'app_name' (snake_case) must not appear in headers"
+        assert 'schema_version' not in headers, "'schema_version' (snake_case) must not appear in headers"
+
+        # Values should be correct
+        assert headers['appName'] == 'service_name'
+        assert headers['schemaVersion'] == 1.0

--- a/tests/broker/test_queue.py
+++ b/tests/broker/test_queue.py
@@ -59,14 +59,20 @@ class TestQueue:
 
     def test_callback_subscribe_sucessffuly(self, setup):
         from event_people import RabbitBroker
-        from event_people import Context
         from event_people import Queue
+        import pika as _pika
 
         with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
             rabbit = RabbitBroker()
             channel = rabbit.get_connection()
+            queue_instance = Queue(channel)
             delivery_tag = Basic.Deliver('consumer_tag_')
-            delivery_tag.routing_key = 'resource.custom.pay'
+            delivery_tag.routing_key = 'resource.custom.pay.all'
             body = { 'amount': 350, 'name': 'George' }
-            context = Context(channel, delivery_tag)
-            Queue._callback(None, channel=channel, delivery_info= delivery_tag, properties=context, payload=body, args=[False, TestQueue.callback, 'callback'])
+            properties = _pika.BasicProperties(headers={})
+            queue_name = 'service_name-resource.custom.pay.all'
+            retry_params = {'max_retries': 3, 'initial_delay': 1000, 'delay_strategy': 'exponential',
+                            'dlq_name': 'service_name_dlq'}
+            queue_instance._callback(channel=channel, delivery_info=delivery_tag,
+                                     properties=properties, payload=body,
+                                     args=[False, TestQueue.callback, None, queue_name, retry_params])

--- a/tests/broker/test_rabbit_broker.py
+++ b/tests/broker/test_rabbit_broker.py
@@ -75,3 +75,40 @@ class TestRabbitBroker:
             event = Event(event_name, body, schema_version)
 
             rabbit.produce(event)
+
+    def test_close_connection_closes_open_connection(self, setup):
+        """close_connection() must close the underlying pika connection when open."""
+        from event_people import RabbitBroker
+
+        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection) as MockConn:
+            rabbit = RabbitBroker()
+            mock_conn = MockConn.return_value
+            mock_conn.is_closed = False
+            rabbit.connection = mock_conn
+
+            rabbit.close_connection()
+
+            mock_conn.close.assert_called_once()
+
+    def test_close_connection_skips_already_closed(self, setup):
+        """close_connection() must not raise when connection is already closed."""
+        from event_people import RabbitBroker
+
+        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection) as MockConn:
+            rabbit = RabbitBroker()
+            mock_conn = MockConn.return_value
+            mock_conn.is_closed = True
+            rabbit.connection = mock_conn
+
+            rabbit.close_connection()  # should not raise
+
+            mock_conn.close.assert_not_called()
+
+    def test_close_connection_with_no_connection(self, setup):
+        """close_connection() must handle None connection gracefully."""
+        from event_people import RabbitBroker
+
+        rabbit = RabbitBroker()
+        rabbit.connection = None
+
+        rabbit.close_connection()  # should not raise

--- a/tests/listeners/test_base_listener.py
+++ b/tests/listeners/test_base_listener.py
@@ -1,0 +1,131 @@
+import pytest
+import mock
+
+
+class TestBaseListener:
+    """Tests for BaseListener — including v1.2.0 class-level retry attributes."""
+
+    def test_base_listener_default_retry_attrs_are_none(self, setup):
+        """Class-level retry attrs default to None (defer to Config)."""
+        from event_people import BaseListener
+        assert BaseListener.max_attempts is None
+        assert BaseListener.initial_delay is None
+        assert BaseListener.delay_strategy is None
+        assert BaseListener.dlq_name is None
+
+    def test_resolve_retry_params_uses_config_defaults(self, setup):
+        """When no class attrs set, _resolve_retry_params falls back to Config."""
+        from event_people import BaseListener
+        from event_people.config import Config
+
+        params = BaseListener._resolve_retry_params()
+        global_cfg = Config.get_retry_config()
+        assert params['max_retries'] == global_cfg['max_attempts']
+        assert params['initial_delay'] == global_cfg['initial_delay']
+        assert params['delay_strategy'] == global_cfg['delay_strategy']
+        assert params['dlq_name'] == global_cfg['dlq_name']
+
+    def test_subclass_overrides_max_attempts(self, setup):
+        """Listener subclass with max_attempts overrides Config default."""
+        from event_people import BaseListener
+
+        class MyListener(BaseListener):
+            max_attempts = 7
+
+        params = MyListener._resolve_retry_params()
+        assert params['max_retries'] == 7
+
+    def test_subclass_overrides_initial_delay(self, setup):
+        from event_people import BaseListener
+
+        class MyListener(BaseListener):
+            initial_delay = 500
+
+        params = MyListener._resolve_retry_params()
+        assert params['initial_delay'] == 500
+
+    def test_subclass_overrides_delay_strategy(self, setup):
+        from event_people import BaseListener
+
+        class MyListener(BaseListener):
+            delay_strategy = 'fixed'
+
+        params = MyListener._resolve_retry_params()
+        assert params['delay_strategy'] == 'fixed'
+
+    def test_subclass_overrides_dlq_name(self, setup):
+        from event_people import BaseListener
+
+        class MyListener(BaseListener):
+            dlq_name = 'my_custom_dlq'
+
+        params = MyListener._resolve_retry_params()
+        assert params['dlq_name'] == 'my_custom_dlq'
+
+    def test_subclass_partial_override(self, setup):
+        """Only set attributes override Config; unset attrs fall back to Config."""
+        from event_people import BaseListener
+        from event_people.config import Config
+
+        class MyListener(BaseListener):
+            max_attempts = 10
+            # initial_delay, delay_strategy, dlq_name not set
+
+        params = MyListener._resolve_retry_params()
+        global_cfg = Config.get_retry_config()
+        assert params['max_retries'] == 10
+        assert params['initial_delay'] == global_cfg['initial_delay']
+        assert params['delay_strategy'] == global_cfg['delay_strategy']
+        assert params['dlq_name'] == global_cfg['dlq_name']
+
+    def test_callback_injects_context_as_instance_attr(self, setup):
+        """BaseListener.callback must set self.context before calling handler."""
+        from event_people import BaseListener, Event
+
+        received = {}
+
+        class MyListener(BaseListener):
+            def handle(self, event):
+                received['context'] = self.context
+                received['event'] = event
+
+        event = Event('resource.custom.receive.all', {'key': 'val'})
+        ctx = mock.MagicMock()
+        MyListener.callback('handle', event, ctx)
+
+        assert received['context'] is ctx
+        assert received['event'] is event
+
+    def test_success_delegates_to_context(self, setup):
+        from event_people import BaseListener
+
+        ctx = mock.MagicMock()
+        listener = BaseListener(ctx)
+        listener.success()
+        ctx.success.assert_called_once()
+
+    def test_fail_delegates_to_context(self, setup):
+        from event_people import BaseListener
+
+        ctx = mock.MagicMock()
+        listener = BaseListener(ctx)
+        listener.fail()
+        ctx.fail.assert_called_once()
+
+    def test_reject_delegates_to_context(self, setup):
+        from event_people import BaseListener
+
+        ctx = mock.MagicMock()
+        listener = BaseListener(ctx)
+        listener.reject()
+        ctx.reject.assert_called_once()
+
+    def test_fixed_event_name_three_parts(self, setup):
+        from event_people import BaseListener
+        result = BaseListener.fixed_event_name('resource.custom.pay', 'all')
+        assert result == 'resource.custom.pay.all'
+
+    def test_fixed_event_name_four_parts(self, setup):
+        from event_people import BaseListener
+        result = BaseListener.fixed_event_name('resource.custom.pay.all', 'service_name')
+        assert result == 'resource.custom.pay.service_name'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
-class TestConfig:
+import pytest
 
+
+class TestConfig:
 
     def test_env_exists(self, setup):
         from event_people.config import Config
@@ -14,5 +16,113 @@ class TestConfig:
         broker = config.get_broker()
         assert broker is not None
 
+    # --- v1.2.0 ---
 
+    def test_hardcoded_retry_defaults(self, setup):
+        """Env vars RABBIT_EVENT_PEOPLE_MAX_RETRIES / RABBIT_EVENT_PEOPLE_RETRY_TTL_MS
+        were removed in v1.2.0; defaults are now hardcoded."""
+        from event_people.config import Config
+        assert Config.MAX_ATTEMPTS == 3
+        assert Config.INITIAL_DELAY == 1000
+        assert Config.DELAY_STRATEGY == 'exponential'
 
+    def test_get_retry_config_returns_initial_delay(self, setup):
+        """get_retry_config() now includes initial_delay (new in v1.2.0)."""
+        from event_people.config import Config
+        cfg = Config.get_retry_config()
+        assert 'max_attempts' in cfg
+        assert 'initial_delay' in cfg
+        assert 'delay_strategy' in cfg
+        assert 'dlq_name' in cfg
+        assert cfg['initial_delay'] == 1000
+        assert cfg['max_attempts'] == 3
+        assert cfg['delay_strategy'] == 'exponential'
+        assert cfg['dlq_name'] == 'service_name_dlq'
+
+    def test_configure_overrides_max_attempts(self, setup):
+        from event_people.config import Config
+        original = Config.MAX_ATTEMPTS
+        try:
+            Config.configure({'max_attempts': 5})
+            assert Config.MAX_ATTEMPTS == 5
+            assert Config.get_retry_config()['max_attempts'] == 5
+        finally:
+            Config.MAX_ATTEMPTS = original
+
+    def test_configure_overrides_initial_delay(self, setup):
+        from event_people.config import Config
+        original = Config.INITIAL_DELAY
+        try:
+            Config.configure({'initial_delay': 2000})
+            assert Config.INITIAL_DELAY == 2000
+            assert Config.get_retry_config()['initial_delay'] == 2000
+        finally:
+            Config.INITIAL_DELAY = original
+
+    def test_configure_overrides_delay_strategy(self, setup):
+        from event_people.config import Config
+        original = Config.DELAY_STRATEGY
+        try:
+            Config.configure({'delay_strategy': 'fixed'})
+            assert Config.DELAY_STRATEGY == 'fixed'
+            assert Config.get_retry_config()['delay_strategy'] == 'fixed'
+        finally:
+            Config.DELAY_STRATEGY = original
+
+    def test_configure_overrides_dlq_name(self, setup):
+        from event_people.config import Config
+        original = Config.DLQ_NAME
+        try:
+            Config.configure({'dlq_name': 'custom_dlq'})
+            assert Config.DLQ_NAME == 'custom_dlq'
+            assert Config.get_retry_config()['dlq_name'] == 'custom_dlq'
+        finally:
+            Config.DLQ_NAME = original
+
+    def test_configure_with_multiple_options(self, setup):
+        from event_people.config import Config
+        orig_ma = Config.MAX_ATTEMPTS
+        orig_id = Config.INITIAL_DELAY
+        orig_ds = Config.DELAY_STRATEGY
+        orig_dlq = Config.DLQ_NAME
+        try:
+            Config.configure({
+                'max_attempts': 7,
+                'initial_delay': 500,
+                'delay_strategy': 'fixed',
+                'dlq_name': 'my_dlq',
+            })
+            cfg = Config.get_retry_config()
+            assert cfg['max_attempts'] == 7
+            assert cfg['initial_delay'] == 500
+            assert cfg['delay_strategy'] == 'fixed'
+            assert cfg['dlq_name'] == 'my_dlq'
+        finally:
+            Config.MAX_ATTEMPTS = orig_ma
+            Config.INITIAL_DELAY = orig_id
+            Config.DELAY_STRATEGY = orig_ds
+            Config.DLQ_NAME = orig_dlq
+
+    def test_configure_none_is_noop(self, setup):
+        """configure(None) should not raise and should leave defaults intact."""
+        from event_people.config import Config
+        Config.configure(None)
+        assert Config.MAX_ATTEMPTS == 3
+        assert Config.INITIAL_DELAY == 1000
+
+    def test_configure_empty_dict_is_noop(self, setup):
+        """configure({}) should not change any defaults."""
+        from event_people.config import Config
+        Config.configure({})
+        assert Config.MAX_ATTEMPTS == 3
+        assert Config.INITIAL_DELAY == 1000
+
+    def test_dlq_name_defaults_to_app_name_dlq(self, setup):
+        """DLQ_NAME=None → get_retry_config returns '{appName}_dlq'."""
+        from event_people.config import Config
+        original = Config.DLQ_NAME
+        try:
+            Config.DLQ_NAME = None
+            assert Config.get_retry_config()['dlq_name'] == 'service_name_dlq'
+        finally:
+            Config.DLQ_NAME = original

--- a/tests/test_deamon.py
+++ b/tests/test_deamon.py
@@ -1,4 +1,6 @@
-from mock import patch
+import signal
+import sys
+from unittest.mock import patch, MagicMock
 import pika
 
 class TestDeamon:
@@ -7,4 +9,54 @@ class TestDeamon:
         with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
             from event_people import Daemon
             Daemon.start()
+
+    def test_bind_signals_registers_sigterm_and_sigint(self, setup):
+        """Daemon.bind_signals must register handlers for SIGTERM and SIGINT."""
+        from event_people import Daemon
+
+        registered = {}
+        original_signal = signal.signal
+
+        def capturing_signal(sig, handler):
+            registered[sig] = handler
+
+        with patch('signal.signal', side_effect=capturing_signal):
+            Daemon.bind_signals()
+
+        assert signal.SIGTERM in registered, "SIGTERM handler not registered"
+        assert signal.SIGINT in registered, "SIGINT handler not registered"
+
+    def test_stop_closes_broker_and_exits(self, setup):
+        """Daemon.stop must close the broker connection and call sys.exit(0)."""
+        from event_people import Daemon
+        from event_people.config import Config
+
+        mock_broker = MagicMock()
+        original_broker = Config.broker
+        try:
+            Config.broker = mock_broker
+
+            with patch('sys.exit') as mock_exit:
+                Daemon.stop()
+
+            mock_broker.close_connection.assert_called_once()
+            mock_exit.assert_called_once_with(0)
+        finally:
+            Config.broker = original_broker
+
+    def test_stop_with_no_broker_still_exits(self, setup):
+        """Daemon.stop must call sys.exit(0) even when no broker is set."""
+        from event_people import Daemon
+        from event_people.config import Config
+
+        original_broker = Config.broker
+        try:
+            Config.broker = None
+
+            with patch('sys.exit') as mock_exit:
+                Daemon.stop()
+
+            mock_exit.assert_called_once_with(0)
+        finally:
+            Config.broker = original_broker
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -50,3 +50,27 @@ class TestEvent:
         resp = json.loads(event.payload())
 
         assert resp['body'] == body
+
+    def test_has_body_returns_true_when_body_present(self, setup):
+        from event_people import Event
+        event = Event(name='resource.custom.receive', body={'amount': 10})
+        assert event.has_body() is True
+
+    def test_has_body_returns_false_when_body_empty(self, setup):
+        from event_people import Event
+        event = Event(name='resource.custom.receive', body={})
+        assert event.has_body() is False
+
+    def test_has_name_returns_true_when_name_present(self, setup):
+        from event_people import Event
+        event = Event(name='resource.custom.receive', body={})
+        assert event.has_name() is True
+
+    def test_increment_retry_count(self, setup):
+        from event_people import Event
+        event = Event(name='resource.custom.receive', body={})
+        assert event.retry_count == 0
+        event.increment_retry_count()
+        assert event.retry_count == 1
+        event.increment_retry_count()
+        assert event.retry_count == 2

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -59,9 +59,8 @@ class TestEvent:
     def test_has_body_returns_false_when_body_none(self, setup):
         """has_body() returns False only when body is None (not for falsy-but-present values)."""
         from event_people import Event
-        # An empty dict is a present (non-None) body — has_body() should be True.
-        event = Event(name='resource.custom.receive', body={})
-        assert event.has_body() is True
+        event = Event(name='resource.custom.receive', body=None)
+        assert event.has_body() is False
 
     def test_has_body_returns_true_for_falsy_non_none_body(self, setup):
         """Falsy-but-present bodies (empty dict) are treated as having a body."""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -56,10 +56,18 @@ class TestEvent:
         event = Event(name='resource.custom.receive', body={'amount': 10})
         assert event.has_body() is True
 
-    def test_has_body_returns_false_when_body_empty(self, setup):
+    def test_has_body_returns_false_when_body_none(self, setup):
+        """has_body() returns False only when body is None (not for falsy-but-present values)."""
+        from event_people import Event
+        # An empty dict is a present (non-None) body — has_body() should be True.
+        event = Event(name='resource.custom.receive', body={})
+        assert event.has_body() is True
+
+    def test_has_body_returns_true_for_falsy_non_none_body(self, setup):
+        """Falsy-but-present bodies (empty dict) are treated as having a body."""
         from event_people import Event
         event = Event(name='resource.custom.receive', body={})
-        assert event.has_body() is False
+        assert event.has_body() is True
 
     def test_has_name_returns_true_when_name_present(self, setup):
         from event_people import Event

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,5 +1,7 @@
+import inspect
 from mock import patch
 import pika
+
 
 class TestListener:
 
@@ -8,7 +10,6 @@ class TestListener:
         print(event.header)
         print(event.body)
         context.success()
-
 
     def test_listen_event_with(self, setup):
         from event_people import Listener
@@ -26,3 +27,39 @@ class TestListener:
 
         with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
             Listener.on('resource.custom.receive', TestListener.callback)
+
+    # --- v1.2.0 ---
+
+    def test_on_signature_has_two_params(self, setup):
+        """Listener.on signature must be on(event_name, callback) — v1.2.0."""
+        from event_people import Listener
+        sig = inspect.signature(Listener.on)
+        params = list(sig.parameters.keys())
+        # Static method: no 'self'. Expect exactly (event_name, callback).
+        assert params == ['event_name', 'callback'], (
+            f"Expected ['event_name', 'callback'], got {params}"
+        )
+
+    def test_on_uses_config_defaults_not_env_vars(self, setup):
+        """Retry config comes from Config defaults, not env vars (v1.2.0 change)."""
+        from event_people import Listener, Config
+        import os
+        # Ensure old env vars are NOT set — should not affect behaviour
+        assert 'RABBIT_EVENT_PEOPLE_MAX_RETRIES' not in os.environ
+        assert 'RABBIT_EVENT_PEOPLE_RETRY_TTL_MS' not in os.environ
+
+        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+            # Should succeed using hardcoded defaults from Config
+            Listener.on('resource.custom.receive.all', TestListener.callback)
+
+    def test_on_applies_config_configure_overrides(self, setup):
+        """Listener.on uses Config.configure() overrides when set."""
+        from event_people import Listener, Config
+        orig_ma = Config.MAX_ATTEMPTS
+        try:
+            Config.configure({'max_attempts': 5})
+            with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+                # Should succeed — just verifying no error with overridden config
+                Listener.on('resource.custom.receive.all', TestListener.callback)
+        finally:
+            Config.MAX_ATTEMPTS = orig_ma

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -44,9 +44,9 @@ class TestListener:
         """Retry config comes from Config defaults, not env vars (v1.2.0 change)."""
         from event_people import Listener, Config
         import os
-        # Ensure old env vars are NOT set — should not affect behaviour
-        assert 'RABBIT_EVENT_PEOPLE_MAX_RETRIES' not in os.environ
-        assert 'RABBIT_EVENT_PEOPLE_RETRY_TTL_MS' not in os.environ
+        # Ensure old env vars are not set — should not affect behaviour
+        os.environ.pop('RABBIT_EVENT_PEOPLE_MAX_RETRIES', None)
+        os.environ.pop('RABBIT_EVENT_PEOPLE_RETRY_TTL_MS', None)
 
         with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
             # Should succeed using hardcoded defaults from Config


### PR DESCRIPTION
## Summary

Implements spec v1.2.0. See [spec/contract.yml](https://github.com/pin-people/event_people/blob/main/spec/contract.yml) for the full contract.

- **Config.configure()** — optional in-code override of global retry defaults (`max_attempts`, `initial_delay`, `delay_strategy`, `dlq_name`). Connection attributes still read from env vars.
- **Hardcoded defaults** — `MAX_ATTEMPTS=3`, `INITIAL_DELAY=1000ms`, `DELAY_STRATEGY=exponential`. Env vars `RABBIT_EVENT_PEOPLE_MAX_RETRIES` and `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` removed.
- **BaseListener class-level DSL** — `max_attempts`, `initial_delay`, `delay_strategy`, `dlq_name` declared on the listener class override Config defaults for that listener only.
- **Listener.on()** — retry params removed from signature.
- **Bug fix** — `topic.py` was using `header.__dict__` (snake_case keys); now uses `header.to_dict()` (camelCase), fixing cross-language incompatibility.
- **New stable methods** — `Event.has_body()`, `Event.has_name()`, `Daemon.stop()`, `Daemon.bind_signals()`, `BaseBroker.close_connection()`.
- `Event.retry_count`, `Context.max_retries`, `Context.is_last_retry`, `RetryManager` promoted to stable.

## Test plan

- [ ] `pytest` — full suite passes
- [ ] `Config.configure()` overrides defaults
- [ ] Per-listener `max_attempts` overrides Config value
- [ ] `header.to_dict()` emits camelCase keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Code-based retry + DLQ configuration via `Config.configure()` (with runtime overrides) replacing environment-driven settings.
  * Improved per-listener retry customization via class attributes and a simplified `Listener.on(event_name, callback=None)` API.
  * Added broker connection cleanup (`close_connection`) and daemon graceful shutdown using SIGTERM/SIGINT handlers.
  * Added `Event.has_body()` and `Event.has_name()` helpers.
* **Documentation**
  * README updated with new retry/DLQ configuration guidance and examples.
* **Tests**
  * Expanded coverage for retry delays, DLQ behavior, connection shutdown, and listener/config overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->