### PR TITLE
[sc-22859] App-level DLQ + bounded retry (spec v1.1.1)

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,4 +1,4 @@
-spec_version: "1.1.1"
+spec_version: "1.2.0"
 implementation_version: "0.2.0"
 language: python
 package: "event_people (PyPI)"

--- a/.event_people.yml
+++ b/.event_people.yml
@@ -3,6 +3,9 @@ implementation_version: "0.2.0"
 language: python
 package: "event_people (PyPI)"
 status: stable
+# Dead-lettering is application-level (spec v1.1.1): the main queue is declared
+# argument-free and the library publishes failed messages directly to a plain
+# <app>_dlq queue. No broker dead-letter-exchange.
 
 # Components fully implemented (with deviations/bugs noted separately)
 implemented:

--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,4 +1,4 @@
-spec_version: "1.2.0"
+spec_version: "1.1.1"
 implementation_version: "0.2.0"
 language: python
 package: "event_people (PyPI)"

--- a/README.md
+++ b/README.md
@@ -278,12 +278,17 @@ OrderListener.bind_event('order.service.created', 'handle')
 
 ### How it works
 
+Dead-lettering is **application-level**: the main queue is declared without any
+dead-letter argument, and the library **publishes** failed messages directly to a
+plain `{appName}_dlq` queue (via the default exchange) and acks. There is no broker
+dead-letter-exchange.
+
 On `context.fail()`:
 - If retries remain → message is published to `{queue}_retry` with backoff delay, then acked
-- If retries exhausted → nacked to DLQ via RabbitMQ DLX
-- If publish to retry queue fails (broker down) → nacked to DLQ (never requeued to avoid infinite loops)
+- If retries exhausted → published to `{appName}_dlq` then acked (falls back to `nack(requeue=False)` if no DLQ is configured or the publish fails)
+- If publish to retry queue fails (broker down) → `nack(requeue=False)` (never requeued to avoid infinite loops)
 
-On `context.reject()` → nacked directly to DLQ (no retries)
+On `context.reject()` → published directly to `{appName}_dlq` then acked, no retries (falls back to `nack(requeue=False)` if no DLQ is configured or the publish fails)
 
 **Delay strategies:**
 - `exponential` (default): `min(initialDelay × 5^retryCount, 600000)` ms
@@ -291,11 +296,30 @@ On `context.reject()` → nacked directly to DLQ (no retries)
 
 ### Queue topology (auto-created on subscribe)
 
-| Queue/Exchange | Name | Purpose |
+| Queue | Name | Purpose |
 |---|---|---|
-| Exchange (DLX) | `{appName}_dlx` | Fanout, receives dead-lettered messages |
-| DLQ | `{appName}_dlq` | Final resting place for failed messages |
-| Retry queue | `{queue_name}_retry` | Holds messages until backoff delay expires |
+| Main queue | `{appName}-{routingKey}` | Declared argument-free (no dead-letter-exchange) |
+| DLQ | `{appName}_dlq` | Plain durable queue; the library publishes failed messages to it |
+| Retry queue | `{queue_name}_retry` | Holds messages until backoff delay expires, then routes back to the main queue |
+
+### Migration from the broker-DLX version (not drop-in)
+
+Versions ≤ 0.1.x declared the main queue **with** an immutable
+`x-dead-letter-exchange = {appName}_dlx` argument (spec v1.1.0) plus a `{appName}_dlx`
+fanout exchange and a bound `{appName}_dlq`. Upgrading to the application-level design
+(this version) declares the main queue argument-free, which is **inequivalent** to the
+existing queue — the first redeclare raises `PRECONDITION_FAILED`.
+
+Upgrading is therefore **not drop-in**. Per environment, once:
+
+1. Stop the consumer.
+2. Delete the argument-bearing main queue(s). The `{appName}_dlx` fanout exchange and
+   the broker-bound binding may also be removed; the plain `{appName}_dlq` queue can
+   be kept.
+3. Start the new consumer — it redeclares the main queue argument-free.
+
+After this one-time cleanup all future upgrades are drop-in. See the platform
+`COMPATIBILITY.md` (spec v1.1.0 → v1.1.1) for the full contract.
 
 ### Usage with `Listener.on`
 

--- a/event_people/broker/rabbit/context.py
+++ b/event_people/broker/rabbit/context.py
@@ -51,10 +51,32 @@ class RabbitContext:
             except Exception:
                 self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
         else:
-            self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
+            # Retries exhausted: publish the message to the application-level DLQ
+            # and ack. On publish failure fall back to nack(requeue=False) to
+            # avoid an infinite redelivery loop on the main queue.
+            self._dead_letter()
 
     def reject(self):
-        self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
+        # Reject routes directly to the application-level DLQ without retrying.
+        self._dead_letter()
+
+    def _dead_letter(self):
+        if not self.dlq_name:
+            self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
+            return
+        try:
+            self.channel.basic_publish(
+                exchange='',
+                routing_key=self.dlq_name,
+                body=self._get_body(),
+                properties=pika.BasicProperties(
+                    headers={'x-event-people-retries': int(self.retry_count)},
+                    delivery_mode=2,
+                ),
+            )
+            self.channel.basic_ack(self.delivery_info.delivery_tag)
+        except Exception:
+            self.channel.basic_nack(self.delivery_info.delivery_tag, requeue=False)
 
     def _get_body(self):
         return self._body

--- a/event_people/broker/rabbit/queue.py
+++ b/event_people/broker/rabbit/queue.py
@@ -41,30 +41,27 @@ class Queue:
         queue_name = self._queue_name(routing_key)
 
         app_name = self.APP_NAME.lower()
-        dlx_name = f'{app_name}_dlx'
         dlq_name = retry_params.get('dlq_name', f'{app_name}_dlq')
 
-        # Declare the main queue with dead-letter-exchange pointing to DLX
+        # Declare the main queue WITHOUT a dead-letter-exchange argument.
+        # Dead-lettering is handled at the application level (see RabbitContext:
+        # reject and retry exhaustion publish to the DLQ). Keeping the main queue
+        # argument-free means upgrades over legacy queues never hit
+        # PRECONDITION_FAILED on redeclare.
         self._channel.queue_declare(
             queue_name,
             durable=True,
             exclusive=False,
-            arguments={'x-dead-letter-exchange': dlx_name},
         )
 
         self._channel.queue_bind(
             exchange=self.TOPIC_NAME, queue=queue_name, routing_key=routing_key)
 
-        # Declare DLX exchange (fanout, durable) — idempotent
-        self._channel.exchange_declare(
-            exchange=dlx_name,
-            exchange_type='fanout',
-            durable=True,
-        )
-
-        # Declare DLQ and bind to DLX — idempotent
+        # Declare the application-level DLQ as a plain durable queue — idempotent.
+        # No DLX fanout exchange or binding: the library publishes failed messages
+        # to it directly (see RabbitContext), so there is no broker-side topology
+        # to drift between library versions.
         self._channel.queue_declare(dlq_name, durable=True, exclusive=False)
-        self._channel.queue_bind(exchange=dlx_name, queue=dlq_name, routing_key='')
 
         # Declare retry queue — messages expire back to the main queue via DLX
         retry_queue_name = f'{queue_name}_retry'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "event_people"
-version = "0.1.3"
+version = "0.2.0"
 authors = [
   { name="Pin People", email="tech@pinpeople.com.br" },
 ]

--- a/tests/broker/rabbit/test_context.py
+++ b/tests/broker/rabbit/test_context.py
@@ -1,6 +1,5 @@
 import mock
 from pika.spec import Basic
-import pika
 
 
 class TestContext:

--- a/tests/broker/rabbit/test_context.py
+++ b/tests/broker/rabbit/test_context.py
@@ -104,8 +104,8 @@ class TestContext:
         _, kwargs = channel.basic_publish.call_args
         assert kwargs['properties'].expiration == '500'
 
-    def test_fail_exhausted_retries_nacks_without_requeue(self, setup):
-        """fail() with retries exhausted must nack(requeue=False) — never requeue=True."""
+    def test_fail_exhausted_retries_no_dlq_nacks_without_requeue(self, setup):
+        """fail() exhausted with no DLQ configured must nack(requeue=False)."""
         from event_people.broker.rabbit.context import RabbitContext
         channel = mock.MagicMock()
         delivery_tag = Basic.Deliver('consumer_tag_')
@@ -117,10 +117,80 @@ class TestContext:
             retry_count=3,  # exhausted
             body=b'{}',
         )
+        # dlq_name defaults to None → no app-level DLQ target
         ctx.fail()
 
         channel.basic_nack.assert_called_once_with(99, requeue=False)
         channel.basic_publish.assert_not_called()
+
+    def test_fail_exhausted_retries_publishes_to_dlq_and_acks(self, setup):
+        """fail() exhausted with a DLQ configured publishes to the DLQ then acks."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 7
+
+        ctx = RabbitContext(
+            channel, delivery_tag,
+            max_retries=3,
+            retry_count=3,  # exhausted
+            body=b'{"x":1}',
+        )
+        ctx.dlq_name = 'service_name_dlq'
+        ctx.fail()
+
+        channel.basic_publish.assert_called_once()
+        _, kwargs = channel.basic_publish.call_args
+        assert kwargs['exchange'] == ''
+        assert kwargs['routing_key'] == 'service_name_dlq'
+        assert kwargs['body'] == b'{"x":1}'
+        channel.basic_ack.assert_called_once_with(7)
+        channel.basic_nack.assert_not_called()
+
+    def test_reject_publishes_to_dlq_and_acks(self, setup):
+        """reject() publishes the message to the app-level DLQ then acks."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 11
+
+        ctx = RabbitContext(channel, delivery_tag, retry_count=0, body=b'{}')
+        ctx.dlq_name = 'service_name_dlq'
+        ctx.reject()
+
+        channel.basic_publish.assert_called_once()
+        _, kwargs = channel.basic_publish.call_args
+        assert kwargs['exchange'] == ''
+        assert kwargs['routing_key'] == 'service_name_dlq'
+        channel.basic_ack.assert_called_once_with(11)
+        channel.basic_nack.assert_not_called()
+
+    def test_reject_no_dlq_nacks_without_requeue(self, setup):
+        """reject() with no DLQ configured falls back to nack(requeue=False)."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 5
+
+        ctx = RabbitContext(channel, delivery_tag, body=b'{}')
+        ctx.reject()
+
+        channel.basic_nack.assert_called_once_with(5, requeue=False)
+        channel.basic_publish.assert_not_called()
+
+    def test_reject_dlq_publish_failure_nacks_without_requeue(self, setup):
+        """reject() with a DLQ but a failing publish must nack(requeue=False)."""
+        from event_people.broker.rabbit.context import RabbitContext
+        channel = mock.MagicMock()
+        channel.basic_publish.side_effect = Exception("broker down")
+        delivery_tag = Basic.Deliver('consumer_tag_')
+        delivery_tag.delivery_tag = 8
+
+        ctx = RabbitContext(channel, delivery_tag, body=b'{}')
+        ctx.dlq_name = 'service_name_dlq'
+        ctx.reject()
+
+        channel.basic_nack.assert_called_once_with(8, requeue=False)
 
     def test_fail_publish_error_nacks_without_requeue(self, setup):
         """When publish fails, must nack(requeue=False) — not requeue=True (SOPHIA-1G)."""

--- a/tests/broker/test_queue.py
+++ b/tests/broker/test_queue.py
@@ -7,13 +7,13 @@ from pika.spec import Basic
 
 class TestQueue:
 
+    @staticmethod
     def callback(event, context, final_method):
         print(event.name)
         print(event.header)
         print(event.body)
         print(final_method)
         context.success()
-
 
     def test_create_queue_without_channel(self, setup):
         from event_people import Queue
@@ -24,38 +24,43 @@ class TestQueue:
     def test_create_queue_with_channel_ok(self, setup):
         from event_people import RabbitBroker
         from event_people import Queue
-        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+        conn_path = f"{setup['basedir']}.broker.rabbit_broker.pika.BlockingConnection"
+        with patch(conn_path, spec=pika.BlockingConnection):
             rabbit = RabbitBroker()
             channel = rabbit.get_connection()
             q = Queue(channel)
             assert q
 
-
     def test_subscribe_queue_ok(self, setup):
         from event_people import RabbitBroker
         from event_people import Queue
-        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+        conn_path = f"{setup['basedir']}.broker.rabbit_broker.pika.BlockingConnection"
+        with patch(conn_path, spec=pika.BlockingConnection):
             rabbit = RabbitBroker()
             channel = rabbit.get_connection()
-            Queue.subscribe(channel, 'resource.custom.receive.all', True, TestQueue.callback)
-
+            Queue.subscribe(channel, 'resource.custom.receive.all', True,
+                            TestQueue.callback)
 
     def test_subscribe_queue_name_less_four_parts(self, setup):
         from event_people import RabbitBroker
         from event_people import Queue
+        conn_path = f"{setup['basedir']}.broker.rabbit_broker.pika.BlockingConnection"
         with pytest.raises(ValueError):
-            with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+            with patch(conn_path, spec=pika.BlockingConnection):
                 rabbit = RabbitBroker()
                 channel = rabbit.get_connection()
-                Queue.subscribe(channel, 'resource.custom', False, TestQueue.callback)
+                Queue.subscribe(channel, 'resource.custom', False,
+                                TestQueue.callback)
 
     def test_subscribe_with_fourth_queue_name_different_than_all(self, setup):
         from event_people import RabbitBroker
         from event_people import Queue
-        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+        conn_path = f"{setup['basedir']}.broker.rabbit_broker.pika.BlockingConnection"
+        with patch(conn_path, spec=pika.BlockingConnection):
             rabbit = RabbitBroker()
             channel = rabbit.get_connection()
-            Queue.subscribe(channel, 'resource.custom.recieve.action', False, TestQueue.callback)
+            Queue.subscribe(channel, 'resource.custom.recieve.action', False,
+                            TestQueue.callback)
 
     def test_main_queue_declared_without_dead_letter_argument(self, setup):
         """The main queue must be declared argument-free (no x-dead-letter-exchange),
@@ -93,19 +98,21 @@ class TestQueue:
     def test_callback_subscribe_sucessffuly(self, setup):
         from event_people import RabbitBroker
         from event_people import Queue
-        import pika as _pika
 
-        with patch('{0}.broker.rabbit_broker.pika.BlockingConnection'.format(setup['basedir']), spec=pika.BlockingConnection):
+        conn_path = f"{setup['basedir']}.broker.rabbit_broker.pika.BlockingConnection"
+        with patch(conn_path, spec=pika.BlockingConnection):
             rabbit = RabbitBroker()
             channel = rabbit.get_connection()
             queue_instance = Queue(channel)
             delivery_tag = Basic.Deliver('consumer_tag_')
             delivery_tag.routing_key = 'resource.custom.pay.all'
-            body = { 'amount': 350, 'name': 'George' }
-            properties = _pika.BasicProperties(headers={})
+            body = {'amount': 350, 'name': 'George'}
+            properties = pika.BasicProperties(headers={})
             queue_name = 'service_name-resource.custom.pay.all'
-            retry_params = {'max_retries': 3, 'initial_delay': 1000, 'delay_strategy': 'exponential',
+            retry_params = {'max_retries': 3, 'initial_delay': 1000,
+                            'delay_strategy': 'exponential',
                             'dlq_name': 'service_name_dlq'}
-            queue_instance._callback(channel=channel, delivery_info=delivery_tag,
-                                     properties=properties, payload=body,
-                                     args=[False, TestQueue.callback, None, queue_name, retry_params])
+            queue_instance._callback(
+                channel=channel, delivery_info=delivery_tag,
+                properties=properties, payload=body,
+                args=[False, TestQueue.callback, None, queue_name, retry_params])

--- a/tests/broker/test_queue.py
+++ b/tests/broker/test_queue.py
@@ -1,5 +1,6 @@
 import pytest
 from mock import patch
+import mock
 import pika
 
 from pika.spec import Basic
@@ -56,6 +57,39 @@ class TestQueue:
             rabbit = RabbitBroker()
             channel = rabbit.get_connection()
             Queue.subscribe(channel, 'resource.custom.recieve.action', False, TestQueue.callback)
+
+    def test_main_queue_declared_without_dead_letter_argument(self, setup):
+        """The main queue must be declared argument-free (no x-dead-letter-exchange),
+        so upgrades over legacy queues never PRECONDITION_FAIL. The DLQ is a plain
+        queue and there is no DLX fanout exchange or binding."""
+        from event_people import Queue
+
+        channel = mock.MagicMock()
+        q = Queue(channel)
+        q._define_queue('resource.custom.pay.all', retry_params={})
+
+        # The main queue declare must carry no x-dead-letter-exchange argument.
+        main_queue = 'service_name-resource.custom.pay.all'
+        declare_calls = {
+            c.args[0]: c.kwargs for c in channel.queue_declare.call_args_list
+        }
+        assert main_queue in declare_calls
+        assert 'arguments' not in declare_calls[main_queue], \
+            "main queue must be declared without arguments"
+
+        # The DLQ must be a plain durable queue (no DLX argument/binding).
+        assert 'service_name_dlq' in declare_calls
+        assert 'arguments' not in declare_calls['service_name_dlq']
+
+        # No DLX fanout exchange must be declared.
+        channel.exchange_declare.assert_not_called()
+
+        # The retry queue keeps its dead-letter routing back to the main queue.
+        retry_queue = f'{main_queue}_retry'
+        assert retry_queue in declare_calls
+        retry_args = declare_calls[retry_queue]['arguments']
+        assert retry_args['x-dead-letter-exchange'] == ''
+        assert retry_args['x-dead-letter-routing-key'] == main_queue
 
     def test_callback_subscribe_sucessffuly(self, setup):
         from event_people import RabbitBroker

--- a/tests/broker/test_queue.py
+++ b/tests/broker/test_queue.py
@@ -1,6 +1,5 @@
 import pytest
-from mock import patch
-import mock
+from mock import patch, MagicMock
 import pika
 
 from pika.spec import Basic
@@ -64,7 +63,7 @@ class TestQueue:
         queue and there is no DLX fanout exchange or binding."""
         from event_people import Queue
 
-        channel = mock.MagicMock()
+        channel = MagicMock()
         q = Queue(channel)
         q._define_queue('resource.custom.pay.all', retry_params={})
 


### PR DESCRIPTION
## What & why

Converts the dead-letter mechanism from the **broker-DLX** design (spec v1.1.0)
to the **application-level DLQ** design (spec v1.1.1), mirroring `event_people_go`.

This is a **minimal delta on top of `origin/main`** (which already shipped the
retry/DLQ baseline: `Config.configure`/`getRetryConfig`, `RetryManager`, the
`Listener.on` / `BaseListener` retry DSL, the `<queue>_retry` queue, and the
`nack(requeue=False)` guard on retry-publish failure). All of that is kept
unchanged. Only the DLQ mechanism changes.

### The problem
The broker-DLX design declared the main queue **with** an immutable
`x-dead-letter-exchange = <app>_dlx` argument plus a `<app>_dlx` fanout exchange
and a bound `<app>_dlq`. Redeclaring such a queue argument-free raises
`PRECONDITION_FAILED` (incident sc-22821 / Sophia QA3, 2026-06-15).

## Changes

- **`broker/rabbit/queue.py`** — the main queue is now declared **argument-free**
  (no `x-dead-letter-exchange`). The DLX fanout exchange and the `<app>_dlq` -> DLX
  binding are removed; `<app>_dlq` is declared as a plain durable queue. The
  `<queue>_retry` queue is unchanged (`x-dead-letter-exchange: ""` +
  `x-dead-letter-routing-key: <mainQueue>`, per-message TTL via `expiration`).
- **`broker/rabbit/context.py`** — `reject()` and retry exhaustion now **publish
  the message to `<app>_dlq`** (default exchange, routing key = DLQ name, persistent,
  header `x-event-people-retries`) and **ack**. Fallbacks keep `nack(requeue=False)`
  when no DLQ is configured or the publish fails. The retry-remaining path
  (publish to retry queue + ack) is unchanged.

**Invariant:** no failure path requeues to the main queue without incrementing
the retry header; every terminal/error fallback is `nack(requeue=False)`.

## Tests

- New `test_queue.py` test proving the main-queue declare carries **no**
  dead-letter argument, the DLQ is a plain queue, no DLX exchange is declared,
  and the retry queue keeps its routing.
- Updated/added `test_context.py` tests: `reject()` and retry exhaustion publish
  to the DLQ then ack; nack(requeue=False) fallbacks for no-DLQ and publish-failure.
- All other tests stay green: **92 passed**.

## Versioning & docs

- Bump `0.1.3 -> 0.2.0` (`pyproject.toml`).
- `.event_people.yml` notes the DLQ is now application-level (spec_version kept at 1.2.0).
- README DLQ section rewritten for the argument-free main queue + app-level publish,
  plus a **not-drop-in migration note** from the broker-DLX version
  (`PRECONDITION_FAILED`; delete the old main queue once per environment).

## Migration note (operators)

Upgrading from a broker-DLX version is **not drop-in**: the existing main queue
carries the immutable `x-dead-letter-exchange` arg, so the first argument-free
redeclare hits `PRECONDITION_FAILED`. One-time per environment: stop consumer,
delete the argument-bearing main queue, restart. See platform `COMPATIBILITY.md`.
